### PR TITLE
chore(npm): changes scope to @hyperledger-labs/

### DIFF
--- a/examples/simple-asset-transfer/app.js
+++ b/examples/simple-asset-transfer/app.js
@@ -1,5 +1,5 @@
-const Validator = require(`@hyperledger/blockchain-integration-framework`).Validator;
-const { genKeyFile } = require(`@hyperledger/blockchain-integration-framework`).cryptoUtils;
+const Validator = require(`@hyperledger-labs/blockchain-integration-framework`).Validator;
+const { genKeyFile } = require(`@hyperledger-labs/blockchain-integration-framework`).cryptoUtils;
 const ConnectorFabric = require(`./fabric/connector`);
 const ConnectorQuorum = require(`./quorum/connector`);
 const ConnectorCorda = require(`./corda/connector`);

--- a/examples/simple-asset-transfer/corda/connector.js
+++ b/examples/simple-asset-transfer/corda/connector.js
@@ -1,6 +1,6 @@
 const rp = require(`request-promise-native`);
 
-const { Connector } = require(`@hyperledger/blockchain-integration-framework`);
+const { Connector } = require(`@hyperledger-labs/blockchain-integration-framework`);
 
 class MyCordaConnector extends Connector.CORDA {
   static formatAsset(asset, targetDLTType) {

--- a/examples/simple-asset-transfer/fabric/connector.js
+++ b/examples/simple-asset-transfer/fabric/connector.js
@@ -1,5 +1,5 @@
 const rp = require(`request-promise-native`);
-const { Connector } = require(`@hyperledger/blockchain-integration-framework`);
+const { Connector } = require(`@hyperledger-labs/blockchain-integration-framework`);
 
 class MyFabricConnector extends Connector.FABRIC {
 

--- a/examples/simple-asset-transfer/package-lock.json
+++ b/examples/simple-asset-transfer/package-lock.json
@@ -1,5 +1,5 @@
 {
-	"name": "@hyperledger/blockchain-integration-framework.simple-asset-transfer",
+	"name": "@hyperledger-labs/blockchain-integration-framework.simple-asset-transfer",
 	"version": "0.1.0",
 	"lockfileVersion": 1,
 	"requires": true,
@@ -1653,7 +1653,7 @@
 				"pend": "~1.2.0"
 			}
 		},
-		"@hyperledger/blockchain-integration-framework": {
+		"@hyperledger-labs/blockchain-integration-framework": {
 			"version": "git+https://gitlab+deploy-token-14:5_sD47zyyyZPCkfRJJsi@code-sa.techlabs.accenture.com/git/blockchain/_exploration/interoperability/after-portal.git#53755ac1e36ede096670708f1f980b8f5b3f93f5",
 			"from": "git+https://gitlab+deploy-token-14:5_sD47zyyyZPCkfRJJsi@code-sa.techlabs.accenture.com/git/blockchain/_exploration/interoperability/after-portal.git#feature/corda-scenario",
 			"requires": {

--- a/examples/simple-asset-transfer/package.json
+++ b/examples/simple-asset-transfer/package.json
@@ -1,8 +1,8 @@
 {
 	"version": "0.1.0",
-	"name": "@hyperledger/blockchain-integration-framework.examples.simple-asset-transfer",
+	"name": "@hyperledger-labs/blockchain-integration-framework.examples.simple-asset-transfer",
 	"dependencies": {
-		"@hyperledger/blockchain-integration-framework": "git+https://github.com/hyperledger-labs/blockchain-integration-framework.git#master",
+		"@hyperledger-labs/blockchain-integration-framework": "git+https://github.com/hyperledger-labs/blockchain-integration-framework.git#master",
 		"cookie-parser": "^1.4.4",
 		"express-bearer-token": "^2.4.0",
 		"express-jwt": "^5.3.1",

--- a/examples/simple-asset-transfer/quorum/api/package-lock.json
+++ b/examples/simple-asset-transfer/quorum/api/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hyperledger/blockchain-integration-framework",
+  "name": "@hyperledger-labs/blockchain-integration-framework",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/examples/simple-asset-transfer/quorum/api/package.json
+++ b/examples/simple-asset-transfer/quorum/api/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "name": "@hyperledger/blockchain-integration-framework.examples.simple-asset-transfer.quorum-api",
+  "name": "@hyperledger-labs/blockchain-integration-framework.examples.simple-asset-transfer.quorum-api",
   "license": "Apache-2.0",
   "scripts": {
     "init": "npm-run-all compile deploy reg",

--- a/examples/simple-asset-transfer/quorum/connector.js
+++ b/examples/simple-asset-transfer/quorum/connector.js
@@ -1,6 +1,6 @@
 const rp = require(`request-promise-native`);
 
-const { Connector } = require(`@hyperledger/blockchain-integration-framework`);
+const { Connector } = require(`@hyperledger-labs/blockchain-integration-framework`);
 
 class MyQuorumConnector extends Connector.QUORUM {
   static formatAsset(asset, targetDLTType) {

--- a/examples/simple-asset-transfer/scenarios/corda-to-fabric.js
+++ b/examples/simple-asset-transfer/scenarios/corda-to-fabric.js
@@ -1,7 +1,7 @@
 const log4js = require(`log4js`);
 const ConnectorCorda = require(`../corda/connector.js`);
 const ConnectorFabric = require(`../fabric/connector.js`);
-const Client = require(`@hyperledger/blockchain-integration-framework`).Client;
+const Client = require(`@hyperledger-labs/blockchain-integration-framework`).Client;
 const conf = require(`./config`);
 
 const logger = log4js.getLogger(`corda-to-fabric`);

--- a/examples/simple-asset-transfer/scenarios/corda-to-quorum.js
+++ b/examples/simple-asset-transfer/scenarios/corda-to-quorum.js
@@ -1,7 +1,7 @@
 const log4js = require(`log4js`);
 const ConnectorCorda = require(`../corda/connector.js`);
 const ConnectorQuorum = require(`../quorum/connector.js`);
-const Client = require(`@hyperledger/blockchain-integration-framework`).Client;
+const Client = require(`@hyperledger-labs/blockchain-integration-framework`).Client;
 const conf = require(`./config`);
 
 const logger = log4js.getLogger(`corda-to-quorum`);

--- a/examples/simple-asset-transfer/scenarios/fabric-to-corda.js
+++ b/examples/simple-asset-transfer/scenarios/fabric-to-corda.js
@@ -1,7 +1,7 @@
 const log4js = require(`log4js`);
 const ConnectorCorda = require(`../corda/connector.js`);
 const ConnectorFabric = require(`../fabric/connector.js`);
-const Client = require(`@hyperledger/blockchain-integration-framework`).Client;
+const Client = require(`@hyperledger-labs/blockchain-integration-framework`).Client;
 const conf = require(`./config`);
 
 const logger = log4js.getLogger(`fabric-to-corda`);

--- a/examples/simple-asset-transfer/scenarios/fabric-to-quorum.js
+++ b/examples/simple-asset-transfer/scenarios/fabric-to-quorum.js
@@ -1,7 +1,7 @@
 const log4js = require(`log4js`);
 const ConnectorQuorum = require(`../quorum/connector.js`);
 const ConnectorFabric = require(`../fabric/connector.js`);
-const Client = require(`@hyperledger/blockchain-integration-framework`).Client;
+const Client = require(`@hyperledger-labs/blockchain-integration-framework`).Client;
 const conf = require(`./config`);
 
 const logger = log4js.getLogger(`fabric-to-quorum`);

--- a/examples/simple-asset-transfer/scenarios/quorum-to-corda.js
+++ b/examples/simple-asset-transfer/scenarios/quorum-to-corda.js
@@ -1,7 +1,7 @@
 const log4js = require(`log4js`);
 const ConnectorCorda = require(`../corda/connector.js`);
 const ConnectorQuorum = require(`../quorum/connector.js`);
-const Client = require(`@hyperledger/blockchain-integration-framework`).Client;
+const Client = require(`@hyperledger-labs/blockchain-integration-framework`).Client;
 const conf = require(`./config`);
 
 const logger = log4js.getLogger(`quorum-to-corda`);

--- a/examples/simple-asset-transfer/scenarios/quorum-to-fabric.js
+++ b/examples/simple-asset-transfer/scenarios/quorum-to-fabric.js
@@ -1,7 +1,7 @@
 const log4js = require(`log4js`);
 const ConnectorQuorum = require(`../quorum/connector.js`);
 const ConnectorFabric = require(`../fabric/connector.js`);
-const Client = require(`@hyperledger/blockchain-integration-framework`).Client;
+const Client = require(`@hyperledger-labs/blockchain-integration-framework`).Client;
 const conf = require(`./config`);
 
 const logger = log4js.getLogger(`quorum-to-fabric`);

--- a/examples/simple-asset-transfer/scenarios/share-pub-keys.js
+++ b/examples/simple-asset-transfer/scenarios/share-pub-keys.js
@@ -2,7 +2,7 @@ const log4js = require(`log4js`);
 const ConnectorCorda = require(`../corda/connector.js`);
 const ConnectorQuorum = require(`../quorum/connector.js`);
 const ConnectorFabric = require(`../fabric/connector.js`);
-const Client = require(`@hyperledger/blockchain-integration-framework`).Client;
+const Client = require(`@hyperledger-labs/blockchain-integration-framework`).Client;
 const conf = require(`./config`);
 
 const logger = log4js.getLogger(`share-public-keys`);

--- a/examples/simple-asset-transfer/tests/connector-fabric.js
+++ b/examples/simple-asset-transfer/tests/connector-fabric.js
@@ -7,7 +7,7 @@ const cp = require(`chai-as-promised`);
 
 const ConnectorFabricEx = require(`../fabric/connector`);
 const config = require(`./config`);
-const { Multisig } = require(`@hyperledger/blockchain-integration-framework`);
+const { Multisig } = require(`@hyperledger-labs/blockchain-integration-framework`);
 
 chai.use(cp);
 

--- a/examples/simple-asset-transfer/tests/connector-quorum.js
+++ b/examples/simple-asset-transfer/tests/connector-quorum.js
@@ -9,7 +9,7 @@ const secp256k1 = require(`secp256k1`);
 
 const ConnectorQuorumEx = require(`../quorum/connector`);
 const config = require(`./config`);
-const { Multisig } = require(`@hyperledger/blockchain-integration-framework`);
+const { Multisig } = require(`@hyperledger-labs/blockchain-integration-framework`);
 
 chai.use(cp);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hyperledger/blockchain-integration-framework",
+  "name": "@hyperledger-labs/blockchain-integration-framework",
   "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "version": "0.1.0",
-  "name": "@hyperledger/blockchain-integration-framework",
+  "name": "@hyperledger-labs/blockchain-integration-framework",
   "license": "Apache-2.0",
   "repository": {
     "type": "git"


### PR DESCRIPTION
Fixes #28
We'll be allowed to use the @hyperledger scope once the project
graduates from the labs.
At that point we can publish the same package contents under multiple package
scopes for each new release to spare early adopters the migration
effort.

Signed-off-by: Peter Somogyvari <peter.somogyvari@accenture.com>